### PR TITLE
Ajout de la promo 1996

### DIFF
--- a/map.csv
+++ b/map.csv
@@ -17,6 +17,6 @@ Remram,Rémi Rampin,2012,2016-09-20,40.79821,-73.96365
 aKron,Bastien Busson,2009,2016-09-20,36.859712,-76.288884
 Phyce,Philippe Guillebert,2006,2016-09-20,49.25683,-123.15060
 guitou,David Marchand,2005,2016-09-20,44.806634,-0.632543
-P.O.,Pierre-Olivier Gaillard,2017-02-06,40.659502,-73.645469
+P.O.,Pierre-Olivier Gaillard,1996,2017-02-06,40.659502,-73.645469
 Garz,Frédéric Garzon,1996,2017-02-06,37.347029,-121.931044
 SuperU,Nicolas Lejeune,1996,2017-02-06,43.295797,5.375253

--- a/map.csv
+++ b/map.csv
@@ -17,3 +17,6 @@ Remram,Rémi Rampin,2012,2016-09-20,40.79821,-73.96365
 aKron,Bastien Busson,2009,2016-09-20,36.859712,-76.288884
 Phyce,Philippe Guillebert,2006,2016-09-20,49.25683,-123.15060
 guitou,David Marchand,2005,2016-09-20,44.806634,-0.632543
+P.O.,Pierre-Olivier Gaillard,2017-02-06,40.659502,-73.645469
+Garz,Frédéric Garzon,1996,2017-02-06,37.347029,-121.931044
+SuperU,Nicolas Lejeune,1996,2017-02-06,43.295797,5.375253


### PR DESCRIPTION
Hello, à l'occasion de la soirée des 25 ans du Rézo vendredi 3
Février, Julien Hémery m'a parlé de cette carte: Voici ma
contribution, les localisations de mes amis du bureau de la promo 1996,
P.O. Gaillard et Nico Lejeune, et de moi-même.
F. Garzon